### PR TITLE
add support for pushing metadata to gesdisc

### DIFF
--- a/pushMetadataToGesdisc.js
+++ b/pushMetadataToGesdisc.js
@@ -1,0 +1,41 @@
+
+const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager');
+
+async function getSecretsValues(){
+    const secretClient = new SecretsManagerClient();
+  const secretCmd = new GetSecretValueCommand({ SecretId: 'gesdisc_endpoint' });
+  return secretClient.send(secretCmd);
+}
+
+async function pushMetadataToDaac(metadata){
+    const secretsResponse = await getSecretsValues();
+    const endpointCreds = JSON.parse(secretsResponse.SecretString);
+    const url = `https://${endpointCreds.gesdisc_endpoint_url}/${endpointCreds.gesdisc_endpoint_access_token}`;
+    metadata["ShortName"] = metadata.EntryTitle;
+    metadata["Version"] = "1";
+    try{
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(metadata),
+        });
+        if(response.status === 200){
+            return 'success';
+        }else{
+            console.error(response)
+            return 'endpoint failed';
+        }
+    }catch(err){
+        console.error(err);
+        return 'endpoint failed';
+    }
+}
+
+async function execute({submission}) {
+  const resp = await pushMetadataToDaac(submission.metadata);
+  console.log(resp);
+}
+
+module.exports.execute = execute;


### PR DESCRIPTION
# Description

Adds support for GES DISC push to daac step.

## Spec

See Ticket: [EDPUB-1001](https://bugs.earthdata.nasa.gov/browse/EDPUB-1001)

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a GESDISC submission.
4. Complete all forms and approve them
5. Confirm it progresses through the automated steps
6. Confirm with GESDISC metadata was received.

Notice this has been validated by GESDISC.  This must be deployed to test but deploying and undeploying the merge for testing will cause issues with AWS secrets that will break other deployments for at least 7 days.
---

## Change Log

Adds support for GES DISC push to daac step.

* [Add _____](link to commitid)
* [Fix _____](link to commitid)